### PR TITLE
Add check_mailqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Follows standard collectd-python plugin configuration. You need to make sure you
 - Configure the plugin in your collectd config `<COLLECTD_ROOT>/etc/conf.d/postfix.conf` or however you include plugins
 
 
-There are only two module config options at the moment - an example config:
+Below is an example module config. Current allowed options are:
+```
+- Verbose (boolean) - use verbose logging 
+- Maillog (string) - location of postfix mail log
+- CheckMailQ (boolean) - check the postfix mail queue (shells out with subprocess)
+```
+
 ```
 <LoadPlugin python>
     Globals true
@@ -28,6 +34,7 @@ There are only two module config options at the moment - an example config:
     <Module postfix>
       Verbose false
       Maillog "/var/log/maillog"
+      CheckMailQ true
     </Module>
 </Plugin>
 ```

--- a/collectd-postfix.py
+++ b/collectd-postfix.py
@@ -10,7 +10,6 @@ import re
 NAME = 'postfix'
 VERBOSE_LOGGING = False
 MAILLOG = '/var/log/maillog'
-MAILLOG_CHUNK = -300000
 CHECK_MAILQUEUE = False
 METRICS = {
   "connection-in-open": "postfix/smtpd[[0-9]+]: connect from",
@@ -103,15 +102,12 @@ NOTE: If your metrics are getting truncated because you have a lot of maillog vo
 """
 def read_log():
   f = open(MAILLOG, 'r')
-  f.seek(MAILLOG_CHUNK, 2)
   lines = f.read()
   return lines
 
 # Return average delay or count of matched lines for each metric_name/regex pair
 def parse_log(lines, metric_name, metric_regex):
   matches = re.findall(metric_regex, lines)
-  if VERBOSE_LOGGING:
-    logger('info',  matches)
   if 'delay' in metric_name:
     #In smaller than 60 second collection intervals, there are issues with null data
     try:

--- a/collectd-postfix.py
+++ b/collectd-postfix.py
@@ -95,11 +95,6 @@ def parse_mailqueue():
 
   return messages
 
-"""
-Read last ~300KB of data to make sure we get at least the whole last minute
-NOTE: If your metrics are getting truncated because you have a lot of maillog volume, increase MAILLOG_CHUNK
-  MAILLOG_CHUNK should always be negative - for more reading look at the python seek() docs
-"""
 def read_log():
   f = open(MAILLOG, 'r')
   lines = f.read()
@@ -109,7 +104,10 @@ def read_log():
 def parse_log(lines, metric_name, metric_regex):
   matches = re.findall(metric_regex, lines)
   if 'delay' in metric_name:
-    #In smaller than 60 second collection intervals, there are issues with null data
+    """
+    In smaller than 60 second collection intervals, there are issues with null data 
+    beacuse collectd-postfix takes ~15 seconds depending on your mail volume
+    """
     try:
       delay = (sum(float(i) for i in matches) / len(matches))
     except ZeroDivisionError:


### PR DESCRIPTION
Adding ability to check/parse mailq. It will return total size of mailq and count of all SMTP response codes/reasons that are present. 